### PR TITLE
Build as module and executable, add argument for log level

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -9,6 +9,8 @@ import os
 import re
 from argparse import ArgumentParser
 
+logger = logging.getLogger(__name__)
+
 
 class DirectoryWalkerGuard(object):
 

--- a/pybind11_stubgen/__main__.py
+++ b/pybind11_stubgen/__main__.py
@@ -1,0 +1,54 @@
+
+import logging, sys, os
+from argparse import ArgumentParser
+from pybind11_stubgen import DirectoryWalkerGuard, ModuleStubsGenerator, recursive_mkdir_walker
+
+_LOG_LEVEL_MAP = {"CRITICAL" : logging.CRITICAL,
+                  "ERROR" : logging.ERROR,
+                  "WARNING" : logging.WARNING,
+                  "INFO" : logging.INFO,
+                  "DEBUG" : logging.DEBUG}
+
+def _log_level_from_string(string):
+    if not string in _LOG_LEVEL_MAP:
+        raise argparse.ArgumentTypeError("Invalid log level choice, available choices are: {}".format(list(_LOG_LEVEL_MAP.keys())))
+    return _LOG_LEVEL_MAP[string]
+
+def main():
+    parser = ArgumentParser(description="Generates stubs for specified modules")
+    parser.add_argument("-o", "--output-dir", dest="output_dir",
+                        help="the root directory for output stubs", default="./stubs")
+    parser.add_argument("--root_module_suffix", type=str, default="-stubs",
+                        help="optional suffix to disambiguate from the "
+                             "original package")
+    parser.add_argument("--no-setup-py", action='store_true')
+    parser.add_argument("module_names", nargs="+", metavar="MODULE_NAME", type=str, help="modules names")
+    parser.add_argument("--log-level", dest="log_level", default="WARNING",
+                        help="Set debug output level")
+
+    sys_args = parser.parse_args()
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    handlers = [stderr_handler]
+
+    logging.basicConfig(
+        level=_log_level_from_string(sys_args.log_level),
+        format='[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s',
+        handlers=handlers
+    )
+
+    output_path = sys_args.output_dir
+
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
+
+    with DirectoryWalkerGuard(output_path):
+        for _module_name in sys_args.module_names:
+            _module = ModuleStubsGenerator(_module_name)
+            _module.parse()
+            _module.stub_suffix = sys_args.root_module_suffix
+            _module.write_setup_py = not sys_args.no_setup_py
+            recursive_mkdir_walker(_module_name.split(".")[:-1], lambda: _module.write())
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     description="PEP 561 type stubs generator for pybind11 modules",
     url="https://github.com/sizmailov/pybind11_stubgen",
     version="0.0.2",
+    entry_points={'console_scripts' : 'py11_stubgen = pybind11_stubgen.__main__:main'},
     packages=['pybind11_stubgen']
 )


### PR DESCRIPTION
This lets the log level be given as an argument --log-level DEBUG.
It creates an executable py11_stubgen (if the name is ok) and installs it in the binary folder. It allows pybind11_stubgen to also be executed as a python module. So valid calls are:
```bash
python3 -m pybind11_stubgen [options] module
```
and
```bash
py11_stubgen [options] module
```
Best
Christopher