### PR TITLE
Missing __module__ fix

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -128,7 +128,7 @@ class StubsGenerator(object):
 
     @staticmethod
     def fully_qualified_name(klass):
-        module_name = klass.__module__
+        module_name = klass.__module__ if hasattr(klass,'__module__') else None
         class_name = klass.__name__
 
         if module_name == "builtins":


### PR DESCRIPTION
Great tool. I had some issues running it on a large module (https://github.com/CadQuery/OCP). Here is the workaround.