### PR TITLE
add nested classes only for the defining class

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -456,7 +456,12 @@ class ClassStubsGenerator(StubsGenerator):
             if inspect.isroutine(member):
                 self.methods.append(ClassMemberStubsGenerator(name, member, self.klass.__module__))
             elif inspect.isclass(member):
-                if member.__name__ not in self.class_name_blacklist:
+                # we may discover a nested class here that is not actually
+                # defined in this class but inherited from a superclass.
+                # in that case we want to associate it only with the
+                # superclass, not the (first) subclass.
+                proper_nested_class = member.__qualname__.startswith(self.klass.__qualname__ + ".")
+                if proper_nested_class and member.__name__ not in self.class_name_blacklist:
                     self.classes.append(ClassStubsGenerator(member))
             elif isinstance(member, property):
                 self.properties.append(PropertyStubsGenerator(name, member, self.klass.__module__))


### PR DESCRIPTION
When there is a superclass X defining a nested class X.Result and
multiple subclasses A(X), B(X) etc., then processing the classes
in alphabetical order and adding nested classes greedily means
that the generated stub file will look like:
```python
class X():
  class Result():
    pass

class A(X):
  class Result():
    # contents of Result class

class B(X):
  class Result():
    pass
```
and therefore we won't be able to successfully use `X.Result.foo` in our
code.

This commit associates nested classes with the place where they are defined
as indicated by the `__qualname__`, so that the resulting file looks like:
```python
class X():
  class Result():
    # contents of Result class

class A(X):
  pass

class B(X):
  pass
```