### PR TITLE
use a fixed commit of pybind11-project-example for tests

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -6,9 +6,11 @@ if [ ! -d pybind11-project-example ]
 then
     git clone https://github.com/sizmailov/pybind11-project-example.git
 else
-    (cd pybind11-project-example; git pull origin)
+    (cd pybind11-project-example; git fetch origin)
 fi
 
+# update the commit below when the example code changes and you want to extend the tests
+(cd pybind11-project-example; git checkout 2310344c932c404d8bcfa2c355f07dcfedcc4082)
 (cd pybind11-project-example; git submodule update --init --recursive)
 (cd pybind11-project-example; python setup.py install)
 


### PR DESCRIPTION
As the example code https://github.com/sizmailov/pybind11-project-example that is used in the tests changes occasionally, I thought it would make sense to reference a fixed commit of the example code, so that updates of the example don't break the CI (as has happened in https://github.com/sizmailov/pybind11-stubgen/pull/26). When we use a fixed commit we can update the example project without worries, and *then* update the main project to reference the updated example code in the tests.