### PR TITLE
Change NoneType to None

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -215,7 +215,10 @@ class StubsGenerator(object):
         class_name = getattr(klass, "__qualname__", klass.__name__)
 
         if module_name == "builtins":
-            return class_name
+            if class_name == 'NoneType':
+                return 'None'
+            else:
+                return class_name
         else:
             return "{module}.{klass}".format(
                 module=module_name,


### PR DESCRIPTION
This occurs when defining an operator== (`__eq__`) in a class. pybind11 currently adds a None `__hash__` function, so the generated stub looks like this:

```pyi
class DemoClass():
    def __eq__(self, arg0: DemoClass) -> bool: ...
    __hash__: NoneType # value = None

```

I'm not convinced this is the best way to deal with this?
