### PR TITLE
Replace default values with uppercase in addition to lowercase hex values

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -33,7 +33,7 @@ class DirectoryWalkerGuard(object):
         os.chdir(os.path.pardir)
 
 
-_default_pybind11_repr_re = re.compile(r'<\w+(\.\w+)* object at 0x[0-9a-f]+>')
+_default_pybind11_repr_re = re.compile(r'<\w+(\.\w+)* object at 0x[0-9a-fA-F]+>')
 
 
 def replace_default_pybind11_repr_with_ellipses(line):


### PR DESCRIPTION
- Fixes stubgen on Windows x64

From https://github.com/robotpy/robotpy-wpilib/runs/1132157020?check_suite_focus=true:

```
[2020-09-18 05:11:26,764] {__init__.py:92} ERROR - Generated stubs signature is degraded to `(*args, **kwargs) -> typing.Any` for
[2020-09-18 05:11:26,764] {__init__.py:96} ERROR - def __init__(self: wpilib.controller._controller.trajectory.TrapezoidProfile, constraints: wpilib.controller._controller.trajectory.TrapezoidProfile.Constraints, goal: wpilib.controller._controller.trajectory.TrapezoidProfile.State, initial: wpilib.controller._controller.trajectory.TrapezoidProfile.State = <wpilib.controller._controller.trajectory.TrapezoidProfile.State object at 0x0000016372EFFC38>) -> None: ...
[2020-09-18 05:11:26,764] {__init__.py:97} ERROR -                                                                                                                                                                                                                                                                                                                     ^-- Invalid syntax

```