### PR TITLE
Clean up docstring indentation

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -378,6 +378,7 @@ class StubsGenerator(object):
 
     @staticmethod
     def format_docstring(docstring):
+        docstring = inspect.cleandoc("\n" + docstring)
         return StubsGenerator.indent('"""\n{}\n"""'.format(docstring.strip("\n")))
 
 

--- a/test/stubs/expected/cpp_library_bindings/_core/issues/__init__.pyi
+++ b/test/stubs/expected/cpp_library_bindings/_core/issues/__init__.pyi
@@ -8,6 +8,6 @@ __all__ = [
 
 def issue_51(arg0: int, arg1: int) -> None:
     """
-        Use-case:
-            issue_51(os.get_handle_inheritable, os.set_handle_inheritable)
+    Use-case:
+        issue_51(os.get_handle_inheritable, os.set_handle_inheritable)
     """


### PR DESCRIPTION
This PR removes common leading whitespace from multiline docstrings using [`inspect.cleandoc()`](https://docs.python.org/3/library/inspect.html#inspect.cleandoc).

For example:
```python
def issue_51(arg0: int, arg1: int) -> None:
    """
        Use-case:
            issue_51(os.get_handle_inheritable, os.set_handle_inheritable)
    """
```
becomes:
```python
def issue_51(arg0: int, arg1: int) -> None:
    """
    Use-case:
        issue_51(os.get_handle_inheritable, os.set_handle_inheritable)
    """
```

The example above is from the stubs generated by the existing test project, so it doesn't seem necessary to create any additional tests.

It's worth noting that `cleandoc()` also converts tabs to spaces and strips empty lines from either end of the docstring (which seems to be correct behaviour). However, if any of this additional behaviour is undesirable, I could use [`textwrap.dedent()`](https://docs.python.org/3/library/textwrap.html#textwrap.dedent) instead, which just removes common leading whitespace.

If the docstring does not start with a newline, `cleandoc()` removes all leading whitespace from every line (which is clearly undesirable).  So, passing:
```python
"""Members:

  ONE

  TWO
"""
```
through `format_docstring()` would result in:
```python
"""
Members:

ONE

TWO
"""
```
Therefore, a newline is added to the beginning of the docstring before it is passed to `cleandoc()`. This additional newline will automatically be removed by `cleandoc()`, and will not affect the resulting docstring.