### PR TITLE
Add support for nested output directories

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -1,5 +1,4 @@
 from typing import Optional, Callable, Iterator, Iterable, List, Set, Mapping, Tuple, Any, Dict
-from functools import cmp_to_key
 import ast
 import warnings
 import importlib

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -54,20 +54,19 @@ def _is_balanced(s):
 
 
 class DirectoryWalkerGuard(object):
-
     def __init__(self, dirname):
         self.dirname = dirname
+        self.origin = os.getcwd()
 
     def __enter__(self):
         if not os.path.exists(self.dirname):
-            os.mkdir(self.dirname)
+            os.makedirs(self.dirname)
 
         assert os.path.isdir(self.dirname)
-
         os.chdir(self.dirname)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        os.chdir(os.path.pardir)
+        os.chdir(self.origin)
 
 
 _default_pybind11_repr_re = re.compile(r'(<(?P<class>\w+(\.\w+)*) object at 0x[0-9a-fA-F]+>)|'
@@ -949,7 +948,7 @@ def main(args=None):
     output_path = sys_args.output_dir
 
     if not os.path.exists(output_path):
-        os.mkdir(output_path)
+        os.makedirs(output_path)
 
     with DirectoryWalkerGuard(output_path):
         for _module_name in sys_args.module_names:


### PR DESCRIPTION
This PR allows for nested directories and improves the `DirectoryWalkerGuard` context manager.

The directory creation logic was not designed to handle nested output directories. It would still work if the nested directories were already present, but a `FileNotFoundError` would be raised if the nested subdirectories didn't exist. Additionally, the `DirectoryWalkerGuard` context manager would return to the parent directory after exiting (instead of the original working directory). This PR fixes these issues and also simplifies directory creation by allowing `DirectoryWalkerGuard` to create all directories.

These changes shouldn't modify any existing functionality, so all the current testing should still be relevant.