### PR TITLE
Use fully qualified name for multi-line attributes

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -450,7 +450,7 @@ class AttributeStubsGenerator(StubsGenerator):
             return [
                        "{name}: {typename} # value = ".format(
                            name=self.name,
-                           typename=str(type(self.attr)))
+                           typename=self.fully_qualified_name(type(self.attr)))
                    ] \
                    + ['"""'] \
                    + [l.replace('"""', r'\"\"\"') for l in value_lines] \

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -431,11 +431,12 @@ class AttributeStubsGenerator(StubsGenerator):
             ]
 
         value_lines = repr(self.attr).split("\n")
+        typename = self.fully_qualified_name(type(self.attr))
+
         if len(value_lines) == 1:
             value = value_lines[0]
             # remove random address from <foo.Foo object at 0x1234>
             value = re.sub(r" at 0x[0-9a-fA-F]+>", ">", value)
-            typename = self.fully_qualified_name(type(self.attr))
             if value == "<{typename} object>".format(typename=typename):
                 value_comment = ""
             else:
@@ -450,7 +451,7 @@ class AttributeStubsGenerator(StubsGenerator):
             return [
                        "{name}: {typename} # value = ".format(
                            name=self.name,
-                           typename=self.fully_qualified_name(type(self.attr)))
+                           typename=typename)
                    ] \
                    + ['"""'] \
                    + [l.replace('"""', r'\"\"\"') for l in value_lines] \


### PR DESCRIPTION
I detected that some attributes were being outputted as `<class CLASSNAME>`.
A quick look into the code showed that one line attributes used the method `fully_qualified_name` to output their typename, but, for multi-line ones, a simple `str(type(attr))` was used.
This pull request changes this behaviour to also use the `fully_qualified_name` on the multi-line ones.