### PR TITLE
fix function signature _find_str_end

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -19,10 +19,11 @@ function_docstring_preprocessing_hooks: List[Callable[[str], str]] = []
 
 
 def _find_str_end(s, start):
-    for i in range(start, len(s)):
-        if i == "\\":  # skip escaped chars
+    for i in range(start + 1, len(s)):
+        c = s[i]
+        if c == "\\":  # skip escaped chars
             continue
-        if i == s[start]:
+        if c == s[start]:
             return i
     return -1
 


### PR DESCRIPTION
When generating stubs for pybind11 functions with default string arguments, the `_find_str_end `function is called.
While iterating over the argument string, it compares the index to the current character which will not work.

This PR fixes this by comparing the current character to the initial character instead.

Example pybind11 binding:

```
class MyClass
{
public:
    void setAuthToken(std::string){};
};

py::class_<MyClass> myclass(m, "MyClass");
myclass.def("set_auth_token", &MyClass::setAuthToken, py::arg("token") = "somedefaultvalue");
```