### PR TITLE
Allow negative values for enum defaults

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -70,7 +70,7 @@ class DirectoryWalkerGuard(object):
 
 
 _default_pybind11_repr_re = re.compile(r'(<(?P<class>\w+(\.\w+)*) object at 0x[0-9a-fA-F]+>)|'
-                                       r'(<(?P<enum>\w+(.\w+)*): \d+>)')
+                                       r'(<(?P<enum>\w+(.\w+)*): -?\d+>)')
 
 
 def replace_default_pybind11_repr(line):


### PR DESCRIPTION
Just extended the `repr` regex to support negative values on enumeration defaults.

Example:

```c++
enum enum_type {
    VALUE = -1
};

py::enum_<enum_type>(m, "enum_type").value("VALUE", VALUE);

m.def("test_negative_value", [] (enum_type v) {}, py::arg("v") = VALUE);
```

When generating the example's stubs, pybind11-stubgen would return an error showing telling that the `test_negative_value` method has invalid signature.

This pull request fixes that kind of problem.