### PR TITLE
Include import on submodules

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -785,6 +785,7 @@ class ModuleStubsGenerator(StubsGenerator):
         for f in self.free_functions:  # type: FreeFunctionStubsGenerator
             result |= f.get_involved_modules_names()
 
+        result.update(m.short_name for m in self.submodules)
         return set(result) - {"builtins", 'typing', self.module.__name__}
 
     def to_lines(self):  # type: () -> List[str]

--- a/test/stubs/expected/cpp_library_bindings/__init__.pyi
+++ b/test/stubs/expected/cpp_library_bindings/__init__.pyi
@@ -6,6 +6,8 @@ from cpp_library_bindings._core import CppException
 from cpp_library_bindings._core import Derived
 from cpp_library_bindings._core import Foo
 from cpp_library_bindings._core import Outer
+import _core
+import core
 import cpp_library_bindings._core
 import cpp_library_bindings._core.copy_types
 import cpp_library_bindings._core.eigen

--- a/test/stubs/expected/cpp_library_bindings/_core/__init__.pyi
+++ b/test/stubs/expected/cpp_library_bindings/_core/__init__.pyi
@@ -1,7 +1,14 @@
 from __future__ import annotations
 import cpp_library_bindings._core
 import typing
+import copy_types
+import eigen
+import invalid_signatures
+import issues
+import numeric
 import numpy.linalg
+import opaque_types
+import sublibA
 
 __all__ = [
     "Base",


### PR DESCRIPTION
This pull request include an import for each submodule of a module.
One might need to use definitions from the submodule(s) on the top-level module, but as it is now, pybind11-stubgen does not import from them.

Example:
```c++
struct ClassC {};
struct ClassB {};
struct ClassA { ClassB attr_b; ClassC attr_c; };

PYBIND11_MODULE(mod_a, m_a) {
  auto m_b = m_a.def_submodule("mod_b");
  auto m_c = m_b.def_submodule("mod_c");

  pybind11::class_<ClassC>(m_c, "ClassC");
  pybind11::class_<ClassB>(m_b, "ClassB");

  pybind11::class_<ClassA>(m_a, "ClassA")
    .def_readonly("attr_b", &ClassA::attr_b)
    .def_readonly("attr_c", &ClassA::attr_c);
}
```

Would generate 3 files / folders:

`mod_a/__init__.pyi`:

```python
from __future__ import annotations
import mod_a
import typing

__all__ = [
    "ClassA",
    "mod_b"
]


class ClassA():
    @property
    def attr_b(self) -> mod_b.ClassB:
        """
        :type: mod_b.ClassB
        """
    @property
    def attr_c(self) -> mod_b.mod_c.ClassC:
        """
        :type: mod_b.mod_c.ClassC
        """
    pass
```

`mod_a/mod_b/__init__.pyi`:

```python
from __future__ import annotations
import mod_a.mod_b
import typing

__all__ = [
    "ClassB",
    "mod_c"
]


class ClassB():
    pass
```

`mod_a/mod_b/mod_c/__init__.pyi`:

```python
from __future__ import annotations
import mod_a.mod_b.mod_c
import typing

__all__ = [
    "ClassC"
]


class ClassC():
    pass
```

Note that `mod_b` is not imported into `mod_a` (nor `mod_c` is imported into `mod_b`), which causes warnings regarding the usage of `mod_b.ClassB` and `mod_b.mod_c.ClassC`.

This pull request adds an import for each submodule (`mod_a` imports `mod_b` and `mod_b` imports `mod_c`), hence, solving that kind of problem.