### PR TITLE
Add support for @classmethod

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -585,8 +585,14 @@ class ClassMemberStubsGenerator(FreeFunctionStubsGenerator):
             )
         for sig in self.signatures:
             args = sig.args
-            if not args.strip().startswith("self"):
-                result.append("@staticmethod")
+            sargs = args.strip()
+            if not sargs.startswith("self"):
+                if sargs.startswith("cls"):
+                    result.append("@classmethod")
+                    # remove type of cls
+                    args = ",".join(["cls"] + sig.split_arguments()[1:])
+                else:
+                    result.append("@staticmethod")
             else:
                 # remove type of self
                 args = ",".join(["self"] + sig.split_arguments()[1:])


### PR DESCRIPTION
Support for https://github.com/pybind/pybind11/pull/4158 if it ever gets merged. I don't see any harm in including this now -- any future classmethod implementations are going to follow the normal python convention of `cls` as the first argument.