### PR TITLE
Add alised class stubgen

### DIFF
--- a/tests/test_alias_class.py
+++ b/tests/test_alias_class.py
@@ -1,33 +1,15 @@
-import sys
-sys.path.insert(0, "..")
-from pybind11_stubgen import ModuleStubsGenerator
 
 class Vector:
-    def __init__(self, x : float, y : float, z : float):
-        self.x = x
-        self.y = y
-        self.z = z
-        
-    def __add__(self, v):
-        return Vector(self.x + v.x, self.y + v.y, self.z + v.z)
-    
-    def __sub__(self, v):
-        return Vector(self.x - v.x, self.y - v.y, self.z - v.z)
-    
-    @property
-    def length(self):
-        return (self.x * self.x + self.y * self.y + self.z * self.z) ** 0.5
-    
-    def normalize(self):
-        len = self.length
-        self.x /= len 
-        self.y /= len 
-        self.z /= len
+  pass
 
 Vector3f = Vector
         
 if __name__ == "__main__":
     import test_alias_class
+    import sys
+    sys.path.insert(0, "..")
+    from pybind11_stubgen import ModuleStubsGenerator
+
 
     generator = ModuleStubsGenerator(test_alias_class)
     generator.parse()

--- a/tests/test_alias_class.py
+++ b/tests/test_alias_class.py
@@ -1,0 +1,36 @@
+import sys
+sys.path.insert(0, "..")
+from pybind11_stubgen import ModuleStubsGenerator
+
+class Vector:
+    def __init__(self, x : float, y : float, z : float):
+        self.x = x
+        self.y = y
+        self.z = z
+        
+    def __add__(self, v):
+        return Vector(self.x + v.x, self.y + v.y, self.z + v.z)
+    
+    def __sub__(self, v):
+        return Vector(self.x - v.x, self.y - v.y, self.z - v.z)
+    
+    @property
+    def length(self):
+        return (self.x * self.x + self.y * self.y + self.z * self.z) ** 0.5
+    
+    def normalize(self):
+        len = self.length
+        self.x /= len 
+        self.y /= len 
+        self.z /= len
+
+Vector3f = Vector
+        
+if __name__ == "__main__":
+    import test_alias_class
+
+    generator = ModuleStubsGenerator(test_alias_class)
+    generator.parse()
+    print('\n'.join(generator.to_lines()))
+
+


### PR DESCRIPTION
I saw the same issue on https://github.com/sizmailov/pybind11-stubgen/pull/63, but it was not merged？Recently I faced the same problem and I solved it.

I tested it on a private project using pybind11 to bind python extensions and pybind11_stubgen to generate stubs, but I can't show those codes, so  I added an simple testing example,  for convenience I just use a module written in python instead of a pybind11 module.

```python
class Vector:
  pass

Vector3f = Vector
```

It will generate stub as follows:

```python
from __future__ import annotations
import test_alias_class
import typing

__all__ = [
    "Vector",
    "Vector3f"
]


class Vector():
    pass
Vector3f = Vector
```

Test result on **current master brunch**:

```python
from __future__ import annotations
import test_alias_class
import typing

__all__ = [
    "Vector",
    "Vector3f"
]


class Vector():
    pass
class Vector():
    pass
```