### PR TITLE
fixes #85

### DIFF
--- a/tests/pybind11-project-example/CMakeLists.txt
+++ b/tests/pybind11-project-example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(pybind11_project_example)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 
 find_package(PythonInterp REQUIRED)

--- a/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
+++ b/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
@@ -42,7 +42,7 @@ PYBIND11_MODULE(_core, m)
 
   auto sublibA = m.def_submodule("sublibA");
   sublibA.def("add", py::overload_cast<int, int>(&cpp_library::sublibA::add), "Add two integers");
-  sublibA.def("add", py::overload_cast<float, float>(&cpp_library::sublibA::add), py::arg("a"), py::arg("b"), "Add two floats");
+  sublibA.def("add", py::overload_cast<float, float>(&cpp_library::sublibA::add), "Add two floats", py::arg("a"), py::arg("b"));
 
   py::enum_<cpp_library::sublibA::ConsoleForegroundColor> (sublibA, "ConsoleForegroundColor")
     .value("Green", cpp_library::sublibA::ConsoleForegroundColor::Green)

--- a/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
+++ b/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
@@ -41,7 +41,8 @@ PYBIND11_MODULE(_core, m)
     .def("g",&cpp_library::Foo::Child::g);
 
   auto sublibA = m.def_submodule("sublibA");
-  sublibA.def("add", cpp_library::sublibA::add);
+  sublibA.def("add", py::overload_cast<int, int>(&cpp_library::sublibA::add), "Add two integers");
+  sublibA.def("add", py::overload_cast<float, float>(&cpp_library::sublibA::add), py::arg("a"), py::arg("b"), "Add two floats");
 
   py::enum_<cpp_library::sublibA::ConsoleForegroundColor> (sublibA, "ConsoleForegroundColor")
     .value("Green", cpp_library::sublibA::ConsoleForegroundColor::Green)

--- a/tests/pybind11-project-example/include/cpp_library/sublibA/add.h
+++ b/tests/pybind11-project-example/include/cpp_library/sublibA/add.h
@@ -3,7 +3,7 @@ namespace sublibA{
 
 int add(int a, int b);
 
-
+float add(float a, float b);
 
 }
 }

--- a/tests/pybind11-project-example/src/sublibA/add.cpp
+++ b/tests/pybind11-project-example/src/sublibA/add.cpp
@@ -3,3 +3,7 @@
 int cpp_library::sublibA::add(int a, int b){
     return a+b;
 }
+
+float cpp_library::sublibA::add(float a, float b){
+    return a+b;
+}

--- a/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
@@ -58,7 +58,7 @@ class VectorPairStringDouble:
     @typing.overload
     def __getitem__(self, arg0: int) -> typing.Tuple[str, float]: ...
     @typing.overload
-    def __getitem__(self, s: slice) -> VectorPairStringDouble: ...
+    def __getitem__(self, s: slice) -> VectorPairStringDouble:
         """
         Retrieve list elements using a slice object
         """

--- a/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
@@ -48,38 +48,39 @@ class VectorPairStringDouble:
     def __delitem__(self, arg0: int) -> None:
         """
         Delete the list elements at index ``i``
-
-        Delete list elements using a slice object
         """
     @typing.overload
-    def __delitem__(self, arg0: slice) -> None: ...
+    def __delitem__(self, arg0: slice) -> None:
+        """
+        Delete list elements using a slice object
+        """
     def __eq__(self, arg0: VectorPairStringDouble) -> bool: ...
     @typing.overload
-    def __getitem__(self, arg0: int) -> typing.Tuple[str, float]:
+    def __getitem__(self, arg0: int) -> typing.Tuple[str, float]: ...
+    @typing.overload
+    def __getitem__(self, s: slice) -> VectorPairStringDouble: ...
         """
         Retrieve list elements using a slice object
         """
     @typing.overload
-    def __getitem__(self, s: slice) -> VectorPairStringDouble: ...
+    def __init__(self) -> None: ...
     @typing.overload
-    def __init__(self) -> None:
+    def __init__(self, arg0: VectorPairStringDouble) -> None:
         """
         Copy constructor
         """
-    @typing.overload
-    def __init__(self, arg0: VectorPairStringDouble) -> None: ...
     @typing.overload
     def __init__(self, arg0: typing.Iterable) -> None: ...
     def __iter__(self) -> typing.Iterator: ...
     def __len__(self) -> int: ...
     def __ne__(self, arg0: VectorPairStringDouble) -> bool: ...
     @typing.overload
-    def __setitem__(self, arg0: int, arg1: typing.Tuple[str, float]) -> None:
+    def __setitem__(self, arg0: int, arg1: typing.Tuple[str, float]) -> None: ...
+    @typing.overload
+    def __setitem__(self, arg0: slice, arg1: VectorPairStringDouble) -> None:
         """
         Assign list elements using a slice object
         """
-    @typing.overload
-    def __setitem__(self, arg0: slice, arg1: VectorPairStringDouble) -> None: ...
     def append(self, x: typing.Tuple[str, float]) -> None:
         """
         Add an item to the end of the list
@@ -96,11 +97,12 @@ class VectorPairStringDouble:
     def extend(self, L: VectorPairStringDouble) -> None:
         """
         Extend the list by appending all the items in the given list
-
-        Extend the list by appending all the items in the given list
         """
     @typing.overload
-    def extend(self, L: typing.Iterable) -> None: ...
+    def extend(self, L: typing.Iterable) -> None:
+        """
+        Extend the list by appending all the items in the given list
+        """
     def insert(self, i: int, x: typing.Tuple[str, float]) -> None:
         """
         Insert an item at a given position.
@@ -109,11 +111,12 @@ class VectorPairStringDouble:
     def pop(self) -> typing.Tuple[str, float]:
         """
         Remove and return the last item
-
-        Remove and return the item at index ``i``
         """
     @typing.overload
-    def pop(self, i: int) -> typing.Tuple[str, float]: ...
+    def pop(self, i: int) -> typing.Tuple[str, float]:
+        """
+        Remove and return the item at index ``i``
+        """
     def remove(self, x: typing.Tuple[str, float]) -> None:
         """
         Remove the first item from the list whose value is x. It is an error if there is no such item.

--- a/tests/stubs/expected/cpp_library_bindings/_core/sublibA/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/sublibA/__init__.pyi
@@ -99,7 +99,14 @@ def accept_defaulted_enum(
     pass
 
 def add(arg0: int, arg1: int) -> int:
-    pass
+    """
+    Add two integers
+    """
+
+def add(a: float, b: float) -> float:
+    """
+    Add two floats
+    """
 
 Blue: cpp_library_bindings._core.sublibA.ConsoleBackgroundColor  # value = <ConsoleBackgroundColor.Blue: 44>
 Green: cpp_library_bindings._core.sublibA.ConsoleBackgroundColor  # value = <ConsoleBackgroundColor.Green: 42>

--- a/tests/stubs/expected/cpp_library_bindings/_core/sublibA/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/sublibA/__init__.pyi
@@ -98,14 +98,16 @@ def accept_defaulted_enum(
 ) -> None:
     pass
 
-def add(arg0: int, arg1: int) -> int:
-    """
-    Add two integers
-    """
-
+@typing.overload
 def add(a: float, b: float) -> float:
     """
     Add two floats
+    """
+
+@typing.overload
+def add(arg0: int, arg1: int) -> int:
+    """
+    Add two integers
     """
 
 Blue: cpp_library_bindings._core.sublibA.ConsoleBackgroundColor  # value = <ConsoleBackgroundColor.Blue: 44>


### PR DESCRIPTION
This PR adds changes to split docs for overloaded functions separately. Added tests for the same.

The idea is to parse the docstrings (which are below the signature) while parsing the `function_signatures_from_docstring` and set it in the `FunctionSignature`. Then, while generating the stubs, we can use the docstring from the `FunctionSignature` instead of the whole docstring.