### PR TITLE
Corrected FixedSize property get signature

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -375,7 +375,7 @@ class StubsGenerator(object):
                     if strip_module_name:
                         line = line.replace(module_name + ".", "")
                     m = re.match(
-                        r"\s*(\w*)\((?P<args>.*)\)\s*->\s*(?P<rtype>[^()]+)\s*",
+                        r"\s*(\w*)\((?P<args>.*)\)\s*->\s*(?P<rtype>.+)\s*",
                         line,
                     )
                     if m:

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setup(
         "console_scripts": "pybind11-stubgen = pybind11_stubgen.__init__:main"
     },
     packages=["pybind11_stubgen"],
+    package_data={"pybind11_stubgen":["py.typed"]},
 )

--- a/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
+++ b/tests/pybind11-project-example/cpp_library_bindings/_core/cpp_library.cpp
@@ -183,6 +183,13 @@ PYBIND11_MODULE(_core, m)
   {
     auto std_array = m.def_submodule("std_array");
     std_array.def("transform", [](const std::array<int, 3>& a){ return a;});
+
+    struct Transform
+    {
+        std::array<int, 3> value;
+    };
+    pybind11::class_<Transform>(std_array, "Transform")
+        .def_readwrite("transform", &Transform::value);
   }
 
 }

--- a/tests/stubs/expected/cpp_library_bindings/_core/std_array/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/std_array/__init__.pyi
@@ -6,7 +6,25 @@ import cpp_library_bindings._core.std_array
 
 import pybind11_stubgen.typing_ext
 
-__all__ = ["transform"]
+__all__ = ["Transform", "transform"]
+
+class Transform:
+    @property
+    def transform(
+        self,
+    ) -> typing.Annotated[typing.List[int], pybind11_stubgen.typing_ext.FixedSize(3)]:
+        """
+        :type: typing.Annotated[typing.List[int], pybind11_stubgen.typing_ext.FixedSize(3)]
+        """
+    @transform.setter
+    def transform(
+        self,
+        arg0: typing.Annotated[
+            typing.List[int], pybind11_stubgen.typing_ext.FixedSize(3)
+        ],
+    ) -> None:
+        pass
+    pass
 
 def transform(
     arg0: typing.Annotated[typing.List[int], pybind11_stubgen.typing_ext.FixedSize(3)]


### PR DESCRIPTION
It was initially suggested in https://github.com/sizmailov/pybind11-stubgen/pull/99/files#diff-2b9c012912fd21677fba400f4b90573daf3a733b47c7912f88c1689c238402f9R372

Also this fixes mypy error (missing py.typed), because pybind11_stubgen.typing_ext is imported.