### PR TITLE
Add special type hinting for __hash__ to declare class as unhashable

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -479,6 +479,10 @@ class AttributeStubsGenerator(StubsGenerator):
         return False
 
     def to_lines(self):  # type: () -> List[str]
+        # special case for __hash__ to mark the surrounding class as unhashable
+        if self.name == "__hash__" and self.attr is None:
+            return ["{name} = None # type: None".format(name=self.name)]
+
         if self.is_safe_to_use_repr(self.attr):
             return ["{name} = {repr}".format(name=self.name, repr=repr(self.attr))]
 

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -481,7 +481,7 @@ class AttributeStubsGenerator(StubsGenerator):
     def to_lines(self):  # type: () -> List[str]
         # special case for __hash__ to mark the surrounding class as unhashable
         if self.name == "__hash__" and self.attr is None:
-            return ["{name} = None # type: None".format(name=self.name)]
+            return ["{name} = None  # type: None".format(name=self.name)]
 
         if self.is_safe_to_use_repr(self.attr):
             return ["{name} = {repr}".format(name=self.name, repr=repr(self.attr))]

--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -481,7 +481,7 @@ class AttributeStubsGenerator(StubsGenerator):
     def to_lines(self):  # type: () -> List[str]
         # special case for __hash__ to mark the surrounding class as unhashable
         if self.name == "__hash__" and self.attr is None:
-            return ["{name} = None  # type: None".format(name=self.name)]
+            return ["__hash__: typing.ClassVar[None] = None"]
 
         if self.is_safe_to_use_repr(self.attr):
             return ["{name} = {repr}".format(name=self.name, repr=repr(self.attr))]

--- a/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
@@ -118,7 +118,7 @@ class VectorPairStringDouble:
         """
         Remove the first item from the list whose value is x. It is an error if there is no such item.
         """
-    __hash__ = None
+    __hash__ = None  # type: None
     pass
 
 def get_complex_map() -> MapStringComplex:

--- a/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
+++ b/tests/stubs/expected/cpp_library_bindings/_core/opaque_types/__init__.pyi
@@ -118,7 +118,7 @@ class VectorPairStringDouble:
         """
         Remove the first item from the list whose value is x. It is an error if there is no such item.
         """
-    __hash__ = None  # type: None
+    __hash__: typing.ClassVar[None] = None
     pass
 
 def get_complex_map() -> MapStringComplex:


### PR DESCRIPTION
Currently, `__hash__ = None` results in a type checking error because it's original type is not optional.
This PR changes that to `__hash__ = None # type: None` to force type checking to pass and the entire class is then correctly recognized as unhashable.