### PR TITLE
Fix base class list

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -212,7 +212,7 @@ class BaseParser(IParser):
     def handle_bases(
         self, path: QualifiedName, bases: tuple[type, ...]
     ) -> list[QualifiedName]:
-        return [self.handle_type(type_) for type_ in bases]
+        return [self.handle_type(type_) for type_ in bases if type_ is not object]
 
     def handle_docstring(self, path: QualifiedName, value: Any) -> Docstring | None:
         if isinstance(value, str):

--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -41,7 +41,7 @@ _generic_args = [
 
 class ParserDispatchMixin(IParser):
     def handle_class(self, path: QualifiedName, class_: type) -> Class | None:
-        base_classes = inspect.getmro(class_)[1:]
+        base_classes = class_.__bases__
         result = Class(name=path[-1], bases=self.handle_bases(path, base_classes))
         for name, member in inspect.getmembers(class_):
             obj = self.handle_class_member(

--- a/tests/py-demo/demo/pure_python/__init__.py
+++ b/tests/py-demo/demo/pure_python/__init__.py
@@ -1,1 +1,1 @@
-from . import functions
+from . import classes, functions

--- a/tests/py-demo/demo/pure_python/classes.py
+++ b/tests/py-demo/demo/pure_python/classes.py
@@ -1,0 +1,14 @@
+class A:
+    """A"""
+
+
+class B(A):
+    """B"""
+
+
+class C(B):
+    """C"""
+
+
+class X(object):
+    pass

--- a/tests/stubs/demo/_bindings/classes.pyi
+++ b/tests/stubs/demo/_bindings/classes.pyi
@@ -9,7 +9,7 @@ class Base:
         pass
     name: str
 
-class CppException(Exception, BaseException, object):
+class CppException(Exception):
     pass
 
 class Derived(Base):

--- a/tests/stubs/demo/pure_python/__init__.pyi
+++ b/tests/stubs/demo/pure_python/__init__.pyi
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import functions
+from . import classes, functions
 
-__all__ = ["functions"]
+__all__ = ["classes", "functions"]

--- a/tests/stubs/demo/pure_python/classes.pyi
+++ b/tests/stubs/demo/pure_python/classes.pyi
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+__all__ = ["A", "B", "C", "X"]
+
+class A(object):
+    """
+    A
+    """
+
+class B(A):
+    """
+    B
+    """
+
+class C(B):
+    """
+    C
+    """
+
+class X(object):
+    pass

--- a/tests/stubs/demo/pure_python/classes.pyi
+++ b/tests/stubs/demo/pure_python/classes.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 __all__ = ["A", "B", "C", "X"]
 
-class A(object):
+class A:
     """
     A
     """
@@ -17,5 +17,5 @@ class C(B):
     C
     """
 
-class X(object):
+class X:
     pass

--- a/tests/stubs/demo/pure_python/functions.pyi
+++ b/tests/stubs/demo/pure_python/functions.pyi
@@ -13,7 +13,7 @@ __all__ = [
     "typing",
 ]
 
-class _Dummy(object):
+class _Dummy:
     @staticmethod
     def foo(): ...
 


### PR DESCRIPTION
Use only direct bases, exclude `object`