### PR TITLE
style: 💄 typing improvements

### DIFF
--- a/pybind11_stubgen/printer.py
+++ b/pybind11_stubgen/printer.py
@@ -136,7 +136,7 @@ class Printer:
                 kw_only = True
             if not pos_only and not arg.pos_only:
                 pos_only = True
-                if sys.version_info[:2] >= (3, 8):
+                if sys.version_info >= (3, 8):
                     args.append("/")
             if not kw_only and arg.kw_only:
                 kw_only = True

--- a/pybind11_stubgen/structs.py
+++ b/pybind11_stubgen/structs.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from dataclasses import field as field_
 from typing import Tuple, Union
 
-if sys.version_info[:2] >= (3, 8):
+if sys.version_info >= (3, 8):
     from typing import Literal
 
     Modifier = Literal["static", "class", None]


### PR DESCRIPTION
I have a draft for #113, and these are some unrelated changes I made in preparation:

1. `CLIArgs` `argparse.Namespace` dataclass for improved type checking in `pybind11_stubgen/__init__.py`
2. not necessary to index `sys.version_info`, and doing so interferes with VS Code's reachability highlighting
3. ~~custom `all_isinstance` `TypeGuard` in `pybind11_stubgen/parser/mixins/fix.py` to resolve a type error in arguments to `FixedSize` vs `DynamicSize`~~
4. use `Sequence` to accept broader types
5. [typo in `FixMissingImport.handle_type`?](https://github.com/sizmailov/pybind11-stubgen/pull/186/files#diff-289d00b72d59bc6abd440cae1271bd3457346ab85a6b53b34c060f26662e482bL115)
6. use comprehension instead of `map`
