### PR TITLE
Option to Specify Path to .so

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import re
 from argparse import ArgumentParser, Namespace
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 from pybind11_stubgen.parser.interface import IParser
@@ -360,9 +361,7 @@ def run(
     writer: Writer,
 ):
     if module_path is not None:
-        py_module = importlib.util.module_from_spec(
-            importlib.util.spec_from_file_location(module_name, module_path)
-        )
+        py_module = module_from_spec(spec_from_file_location(module_name, module_path))
     else:
         py_module = importlib.import_module(module_name)
 


### PR DESCRIPTION
I've added an option to specify the path to directly import the a compiled pybind11 .so file so that this can be used without "installing" the library. This could be particularly useful for running pybind11-stubgen after compilation within setup.py.

```sh
pybind11-stubgen my_module --module-path build/my_module.cpython-310-x86_64-linux-gnu.so
```

```python3
# General gist of usage in setup.py
class CMakeBuild(build_ext):
    def build_extension(self, ext: CMakeExtension) -> None:
    ........
        subprocess.run(
            ["cmake", str(ext.source_dir), *cmake_args], cwd=build_temp, check=True
        )
        subprocess.run(
            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
        )
        subprocess.run(
            [
                "pybind11-stubgen",
                "_sc2_replay_reader",
                f"-o={extdir}",
                f"--module-path={ext_fullpath}",
            ],
            check=True,
        )
```