### PR TITLE
Add support for additional numpy data types

### DIFF
--- a/pybind11_stubgen/parser/mixins/fix.py
+++ b/pybind11_stubgen/parser/mixins/fix.py
@@ -514,9 +514,13 @@ class FixNumpyArrayDimAnnotation(IParser):
         map(
             lambda name: QualifiedName.from_str(f"numpy.{name}"),
             (
+                "uint8",
                 "int8",
+                "uint16",
                 "int16",
+                "uint32",
                 "int32",
+                "uint64",
                 "int64",
                 "float16",
                 "float32",


### PR DESCRIPTION
When `--numpy-array-use-type-var` is specified and the parameter of `numpy.array` is `numpy.uint8`, it still generates `numpy.ndarray[numpy.uint8]`.

