### PR TITLE
Fix `__hash__` type annotation

### DIFF
--- a/pybind11_stubgen/parser/mixins/fix.py
+++ b/pybind11_stubgen/parser/mixins/fix.py
@@ -307,7 +307,7 @@ class FixMissingNoneHashFieldAnnotation(IParser):
             return None
         if field is None and path[-1] == "__hash__":
             result.attribute.annotation = self.parse_annotation_str(
-                "typing.ClassVar[None]"
+                "typing.ClassVar[typing.Any]"
             )
         return result
 

--- a/tests/stubs/python-3.12/pybind11-master/numpy-array-use-type-var/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.12/pybind11-master/numpy-array-use-type-var/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty

--- a/tests/stubs/python-3.12/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.12/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty

--- a/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView[complex]: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty

--- a/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView[MapStringComplex]: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty

--- a/tests/stubs/python-3.7/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.7/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty

--- a/tests/stubs/python-3.8/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
+++ b/tests/stubs/python-3.8/pybind11-master/numpy-array-wrap-with-annotated/demo/_bindings/stl_bind.pyi
@@ -33,7 +33,7 @@ class MapStringComplex:
     def values(self) -> typing.ValuesView: ...
 
 class VectorPairStringDouble:
-    __hash__: typing.ClassVar[None] = None
+    __hash__: typing.ClassVar[typing.Any] = None
     def __bool__(self) -> bool:
         """
         Check whether the list is nonempty


### PR DESCRIPTION
Annotating the type of this as `None` like is currently done causes mypy to generate an error, like this:

```
hash.py:2: error: Incompatible types in assignment (expression has type "None", base class "object" defined the type as "Callable[[object], int]")
```

https://github.com/python/mypy/issues/4266

Annotating this as `ClassVar[Any]` seems to work.  My other attempt of annotating as e.g. `Optional[Callable]` doesn't