### PR TITLE
CI: Unbreak Eigen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
             -   name: Install demo module
                 shell: bash
-                run: ./tests/install-demo-module.sh --pybind11-branch "${{ matrix.pybind11-branch }}" --eigen-branch "master"
+                run: ./tests/install-demo-module.sh --pybind11-branch "${{ matrix.pybind11-branch }}" --eigen-branch "3.2.10"
 
             -   name: Check stubs generation
                 shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
             matrix:
                 test-package: [ "gemmi" ]
                 python:
+                    - "3.13"
+                    - "3.12"
                     - "3.11"
                     - "3.10"
                     - "3.9"
-                    - "3.8"
-                    - "3.7"
         steps:
             -   uses: actions/checkout@v4
 


### PR DESCRIPTION
Eigen 3.3+ changed their internal BLAS build logic, which will need a deeper look why it does not work. Just setting the flag to build BLAS is overwritten by other logic with the Fortran compiler, which breaks current CI.

This should unbreak CI. A follow-up could look into the 3.3+ and again changing logic of 3.4+ of Eigen3: https://gitlab.com/libeigen/eigen/-/blob/master/CMakeLists.txt