### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.5.2 (Feb 24, 2025)
+--------------------------
+Changes:
+- ✨ Ignore technical dunder Python 3.13 fields (`__static_attributes__` and `__firstlineno__`): (#243) by @nim65s
+- 🔧 CI: Drop Python 3.7, add Python 3.13 (#243) by @nim65s
+
 
 Version 2.5.1 (Mar 26, 2024)
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     maintainer_email="sergei.a.izmailov@gmail.com",
     description="PEP 561 type stubs generator for pybind11 modules",
     url="https://github.com/sizmailov/pybind11-stubgen",
-    version="2.5.1",
+    version="2.5.2",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     license="BSD",


### PR DESCRIPTION
Changes:
- ✨ Ignore technical dunder Python 3.13 fields (`__static_attributes__` and `__firstlineno__`): (#243) by @nim65s
- 🔧 CI: Drop Python 3.7, add Python 3.13 (#243) by @nim65s