### PR TITLE
ci: bump version of upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
             -   name: Build dist
                 run: pipx run build --sdist --wheel
 
-            -   uses: actions/upload-artifact@v2
+            -   uses: actions/upload-artifact@v4
                 with:
                     path: |
                         dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 Changelog
 =========
 
-Version 2.5.2 (Feb 24, 2025)
+Version 2.5.3 (Feb 24, 2025)
 --------------------------
 Changes:
 - ✨ Ignore technical dunder Python 3.13 fields (`__static_attributes__` and `__firstlineno__`): (#243) by @nim65s
 - 🔧 CI: Drop Python 3.7, add Python 3.13 (#243) by @nim65s
+
+
+Version 2.5.2 (Feb 24, 2025)
+--------------------------
+Yanked to CI failure, released as 2.5.3
 
 
 Version 2.5.1 (Mar 26, 2024)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     maintainer_email="sergei.a.izmailov@gmail.com",
     description="PEP 561 type stubs generator for pybind11 modules",
     url="https://github.com/sizmailov/pybind11-stubgen",
-    version="2.5.2",
+    version="2.5.3",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     license="BSD",


### PR DESCRIPTION
Publish of `v2.5.2` failed due to outdated `upload-artifact` 
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```