### PR TITLE
Improve package detection

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -107,7 +107,8 @@ class ParserDispatchMixin(IParser):
             elif isinstance(obj, TypeVar_):
                 result.type_vars.append(obj)
             elif obj is None:
-                pass
+                if name == "__path__":
+                    result.is_package = True
             else:
                 raise AssertionError()
 

--- a/pybind11_stubgen/structs.py
+++ b/pybind11_stubgen/structs.py
@@ -199,3 +199,4 @@ class Module:
     imports: set[Import] = field_(default_factory=set)
     aliases: list[Alias] = field_(default_factory=list)
     type_vars: list[TypeVar_] = field_(default_factory=list)
+    is_package: bool = field_(default=False)

--- a/pybind11_stubgen/writer.py
+++ b/pybind11_stubgen/writer.py
@@ -16,7 +16,7 @@ class Writer:
     ):
         assert to.exists()
         assert to.is_dir()
-        if module.sub_modules or sub_dir is not None:
+        if module.sub_modules or module.is_package or sub_dir is not None:
             if sub_dir is None:
                 sub_dir = Path(module.name)
             module_dir = to / sub_dir


### PR DESCRIPTION
If a module has an `__path__` attribute it should be treated as a package even if it doesn't have any submodules.