### PR TITLE
Fix qualname prefix in pybind11 3.0.0

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -418,10 +418,12 @@ class BaseParser(IParser):
             if qual_name is None:
                 self.report_error(NameResolutionError(path))
                 return None
-            # Note: `PyCapsule.` prefix in __qualname__ is an artefact of pybind11
-            _PyCapsule = "PyCapsule."
-            if qual_name.startswith(_PyCapsule):
-                qual_name = qual_name[len(_PyCapsule) :]
+            # Note: __qualname__ prefix is an artefact of pybind11
+            # `PyCapsule.` in pybind11 2
+            # pybind11_detail_function_record_* in 3
+            match = re.match(r"(PyCapsule|pybind11_detail_function_record_[_a-zA-Z0-9]+)\.", qual_name)
+            if match:
+                qual_name = qual_name[match.end():]
             origin_full_name = f"{module_name}.{qual_name}"
 
         origin_name = QualifiedName.from_str(origin_full_name)

--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -421,9 +421,12 @@ class BaseParser(IParser):
             # Note: __qualname__ prefix is an artefact of pybind11
             # `PyCapsule.` in pybind11 2
             # pybind11_detail_function_record_* in 3
-            match = re.match(r"(PyCapsule|pybind11_detail_function_record_[_a-zA-Z0-9]+)\.", qual_name)
+            match = re.match(
+                r"(PyCapsule|pybind11_detail_function_record_[_a-zA-Z0-9]+)\.",
+                qual_name,
+            )
             if match:
-                qual_name = qual_name[match.end():]
+                qual_name = qual_name[match.end() :]
             origin_full_name = f"{module_name}.{qual_name}"
 
         origin_name = QualifiedName.from_str(origin_full_name)


### PR DESCRIPTION
Pybind11 3 changed the holder for functions to a type starting with `pybind11_detail_function_record_`
Eg `pybind11_detail_function_record_v1_msvc_md_mscver19`
This breaks the old implementation.
This fix should fix all the cases.