### PR TITLE
Fix the type annotation for __all__

### DIFF
--- a/pybind11_stubgen/parser/mixins/fix.py
+++ b/pybind11_stubgen/parser/mixins/fix.py
@@ -256,7 +256,7 @@ class FixMissing__all__Attribute(IParser):
             Attribute(
                 name=Identifier("__all__"),
                 value=self.handle_value(all_names),
-                # annotation=ResolvedType(name=QualifiedName.from_str("list")),
+                annotation=ResolvedType(name=QualifiedName.from_str("list[str]")),
             )
         )
 


### PR DESCRIPTION
The lack of annotation makes mypy unhappy.

We've been using this fix at https://github.com/colmap/colmap for 1 year without issue.