### PR TITLE
Remove current module from nested types

### DIFF
--- a/pybind11_stubgen/parser/mixins/fix.py
+++ b/pybind11_stubgen/parser/mixins/fix.py
@@ -469,8 +469,14 @@ class FixCurrentModulePrefixInTypeNames(IParser):
     ) -> ResolvedType | InvalidExpression | Value:
         result = super().parse_annotation_str(annotation_str)
         if isinstance(result, ResolvedType):
-            result.name = self._strip_current_module(result.name)
+            self._strip_current_module_recursive(result)
         return result
+
+    def _strip_current_module_recursive(self, result: ResolvedType):
+        result.name = self._strip_current_module(result.name)
+        for parameter in result.parameters or ():
+            if isinstance(parameter, ResolvedType):
+                self._strip_current_module_recursive(parameter)
 
     def _strip_current_module(self, name: QualifiedName) -> QualifiedName:
         if name[: len(self.__current_module)] == self.__current_module:

--- a/tests/py-demo/bindings/src/modules/functions.cpp
+++ b/tests/py-demo/bindings/src/modules/functions.cpp
@@ -9,6 +9,9 @@
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
 
+#include <variant>
+#include <list>
+
 #include <demo/sublibA/add.h>
 
 namespace {
@@ -97,4 +100,5 @@ void bind_functions_module(py::module &&m) {
     pyFoo.def(py::init<int>());
     m.def("default_custom_arg", [](Foo &foo) {}, py::arg_v("foo", Foo(5), "Foo(5)"));
     m.def("pass_callback", [](std::function<Foo(Foo &)> &callback) { return Foo(13); });
+    m.def("nested_types", [](std::variant<std::list<Foo>, Foo> arg){ return arg; });
 }

--- a/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.11/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -18,6 +18,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -51,6 +52,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...

--- a/tests/stubs/python-3.12/pybind11-v2.12/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.12/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -53,6 +54,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...

--- a/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-use-type-var/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-use-type-var/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -53,6 +54,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...

--- a/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -53,6 +54,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...

--- a/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.12/pybind11-v2.9/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -17,6 +17,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -49,6 +50,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...

--- a/tests/stubs/python-3.8/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
+++ b/tests/stubs/python-3.8/pybind11-v2.13/numpy-array-wrap-with-annotated/demo/_bindings/functions.pyi
@@ -19,6 +19,7 @@ __all__: list[str] = [
     "func_w_named_pos_args",
     "generic",
     "mul",
+    "nested_types",
     "pass_callback",
     "pos_kw_only_mix",
     "pos_kw_only_variadic_mix",
@@ -53,6 +54,7 @@ def mul(p: float, q: float) -> float:
     Multiply p and q (double)
     """
 
+def nested_types(arg0: list[Foo] | Foo) -> list[Foo] | Foo: ...
 def pass_callback(arg0: typing.Callable[[Foo], Foo]) -> Foo: ...
 def pos_kw_only_mix(i: int, /, j: int, *, k: int) -> tuple: ...
 def pos_kw_only_variadic_mix(i: int, /, j: int, *args, k: int, **kwargs) -> tuple: ...


### PR DESCRIPTION
Types like union types have nested types in them.
The current implementation only removes the current module name from the root type name.
This modifies that behaviour so that it expands nested types recursively.
I discovered this through a mypy error that the module had not been imported.

Current behaviour
```py
class Foo:
    pass

def test(arg: list[module.Foo] | module.Foo]) -> None: ...
```

Expected behaviour
```py
class Foo:
    pass

def test(arg: list[Foo] | Foo]) -> None: ...
```