### PR TITLE
Stabilize ordering of `import` vs. `import ... as`

### DIFF
--- a/pybind11_stubgen/printer.py
+++ b/pybind11_stubgen/printer.py
@@ -217,7 +217,7 @@ class Printer:
         if module.doc is not None:
             result.extend(self.print_docstring(module.doc))
 
-        for import_ in sorted(module.imports, key=lambda x: x.origin):
+        for import_ in sorted(module.imports, key=lambda x: (x.origin, x.name or "")):
             result.extend(self.print_import(import_))
 
         for sub_module in module.sub_modules:


### PR DESCRIPTION
Due to an alias, pytango's stubs include the following lines:

```
from tango._tango import CmdArgType
from tango._tango import CmdArgType as ArgType
```

However, pybind11-stubgen doesn't sort these reliably.  I noticed this because of a failure from Debian's reproducible builds system (https://reproduce.debian.net/amd64/api/v1/builds/153381/artifacts/383911/diffoscope) showing that those two lines had been generated in the opposite order. The intent seems to be to sort the output predictably, so let's constrain this a little more tightly.