### PR TITLE
add current directory to sys.path for Windows module resolution

### DIFF
--- a/pybind11_stubgen/__init__.py
+++ b/pybind11_stubgen/__init__.py
@@ -6,6 +6,7 @@ import re
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from pathlib import Path
+import sys
 
 from pybind11_stubgen.parser.interface import IParser
 from pybind11_stubgen.parser.mixins.error_handlers import (
@@ -350,6 +351,7 @@ def run(
     dry_run: bool,
     writer: Writer,
 ):
+    sys.path.insert(0, str(Path.cwd().resolve()))
     modules = []
     for module_name in module_names:
         module = parser.handle_module(


### PR DESCRIPTION
On Windows, when running pybind11-stubgen from a build directory
(e.g., via CMake), the compiled module (.pyd file) cannot be found
because it's not in Python's search path.

This fix adds the current working directory to sys.path before
importing the module, ensuring compatibility with Windows builds
where the module exists in the build directory.

Example on Windows:
  build/src/mymodule.cp311-win_amd64.pyd  ← exists but not found

Without this fix:
  ModuleNotFoundError: No module named 'mymodule'

With this fix:
  Module imports successfully ✓