### PR TITLE
read out class.__dict__ to avoid concurrent modification

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -77,7 +77,8 @@ class ParserDispatchMixin(IParser):
         # Iterate __dict__ keys for definition order, but resolve values
         # through getattr() so descriptors (staticmethod, properties, etc.)
         # are properly unwrapped — matching inspect.getmembers() semantics.
-        for name in class_.__dict__:
+        names = list(class_.__dict__);
+        for name in names:
             seen.add(name)
             try:
                 value = getattr(class_, name)

--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -77,7 +77,7 @@ class ParserDispatchMixin(IParser):
         # Iterate __dict__ keys for definition order, but resolve values
         # through getattr() so descriptors (staticmethod, properties, etc.)
         # are properly unwrapped — matching inspect.getmembers() semantics.
-        names = list(class_.__dict__);
+        names = list(class_.__dict__)
         for name in names:
             seen.add(name)
             try:


### PR DESCRIPTION
Fix `RuntimeError: dictionary changed size during iteration` in `ParserDispatchMixin._iter_class_members` when handling a class whose `__dict__` is updated by `getattr`. Fix is to read out `__dict__` keys into a list then iter. Resolves #309.