### PR TITLE
add angle brackets to docstring type stack parsing

### DIFF
--- a/pybind11_stubgen/parser/mixins/parse.py
+++ b/pybind11_stubgen/parser/mixins/parse.py
@@ -800,7 +800,7 @@ class ExtractSignaturesFromPybind11Docstrings(IParser):
     ) -> list[tuple[str, str | None, str | None]] | None:
         result = []
 
-        closing = {"(": ")", "{": "}", "[": "]"}
+        closing = {"(": ")", "{": "}", "[": "]", "<": ">"}
         stack = []
         i = 0
         arg_begin = 0
@@ -867,7 +867,7 @@ class ExtractSignaturesFromPybind11Docstrings(IParser):
 
     def _split_str(self, param_str: str, delim: str):
         result = []
-        closing = {"(": ")", "{": "}", "[": "]"}
+        closing = {"(": ")", "{": "}", "[": "]", "<": ">"}
         stack = []
         i = 0
         arg_begin = 0


### PR DESCRIPTION
adds "<": ">" to the stack-parsing logic in `ExtractSignaturesFromPybind11Docstrings._split_args_str` and `ExtractSignaturesFromPybind11Docstrings._split_str`, allowing for C++ templated classes with multiple type arguments to be parsed properly. 

Previously, due to the commas, each type in a template is parsed as a separate argument, leading to extra parameters in stubs with nonsensical (often duplicate) names. For example `void f(std::pair<std::pair<std::int,std::string>, std::pair<std::int,std::string>> arg0)` would get parsed as `arg0: "std::pair<std::pair<std::int", std: ":int,std::string>", std: ":pair<std::int", std: ":string>>"`. The nonsensical type strings of course get converted to "...", but the extra duplicate names remain making the stubs unparseable. Adding brackets to the stack correctly activates the logic to only separate by commas if there are no enclosing brackets/parentheses/etc.